### PR TITLE
Remove uniswap setup instructions from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,6 @@ In the project root, run:
 
 `yarn`
 
-Then in `src/components/uniswap`, run the following:
-
-`yarn && yarn compile-contract-types && yarn graphql-codegen && yarn i18n:extract`
-
 ## Available Scripts
 
 In the project directory, you can run:


### PR DESCRIPTION
While creating the other PR, noticed that there are some out of date uniswap instructions in the README that we can get rid of.