### PR TITLE
Improve waitFor framework. Introduce a PropertyKeyOf<T> utility type for safely objectifying types into a (keyof T)[].

### DIFF
--- a/src/slices/index.ts
+++ b/src/slices/index.ts
@@ -37,3 +37,12 @@ export const getGenericReducerBuilder = <Args extends {}, Value>(
       state.value = action.payload
     })
 }
+
+/* Utility type for creating an object from an 'Args' type.
+ *
+ * This ensures the keys of object are equivalent to keys of type.
+ * Values of keys are `true` and used only for object creation.
+ * 
+ * NOTE: This enables `waitFor` dependencies to be specified within each slice.
+ */
+export type PropertyKeysOf<T> = { [P in keyof Required<T>]: true };

--- a/src/slices/liquidations/index.ts
+++ b/src/slices/liquidations/index.ts
@@ -18,6 +18,13 @@ export type liquidationsArgs = {
   trustlessMulticall: string,
 }
 
+type KeysEnum<T> = { [P in keyof Required<T>]: true };
+const liquidationDependencies: KeysEnum<liquidationsArgs> = {
+  contracts: true,
+  trustlessMulticall: true,
+};
+export const liquidationsDeps = Object.keys(liquidationDependencies) as (keyof liquidationsArgs)[];
+
 export interface LiquidationsState extends sliceState<liquidationsInfo> {}
 
 export const getLiquidationsInfo = createAsyncThunk(

--- a/src/slices/liquidations/index.ts
+++ b/src/slices/liquidations/index.ts
@@ -1,5 +1,5 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
-import { sliceState, getStateWithValue, getGenericReducerBuilder } from '../'
+import { sliceState, getStateWithValue, getGenericReducerBuilder, PropertyKeysOf} from '../'
 import getContract, { getMulticallContract } from '../../utils/getContract'
 
 import { Liquidations } from '@trustlessfi/typechain'
@@ -18,12 +18,11 @@ export type liquidationsArgs = {
   trustlessMulticall: string,
 }
 
-type KeysEnum<T> = { [P in keyof Required<T>]: true };
-const liquidationDependencies: KeysEnum<liquidationsArgs> = {
+const liquidationPropertyKeys: PropertyKeysOf<liquidationsArgs> = {
   contracts: true,
   trustlessMulticall: true,
 };
-export const liquidationsDeps = Object.keys(liquidationDependencies) as (keyof liquidationsArgs)[];
+export const liquidationsDeps = Object.keys(liquidationPropertyKeys) as (keyof liquidationsArgs)[];
 
 export interface LiquidationsState extends sliceState<liquidationsInfo> {}
 

--- a/src/slices/waitFor.ts
+++ b/src/slices/waitFor.ts
@@ -10,7 +10,7 @@ import { getPoolsCurrentData, poolsCurrentInfo } from './poolsCurrentData'
 import { getLiquidityPositions } from './liquidityPositions'
 import { getPositions } from './positions'
 import { getSystemDebtInfo, systemDebtInfo } from './systemDebt'
-import { getLiquidationsInfo, liquidationsInfo } from './liquidations'
+import { getLiquidationsInfo, liquidationsInfo, liquidationsDeps} from './liquidations'
 import { getRewardsInfo, rewardsInfo } from './rewards'
 import { getPricesInfo } from './prices'
 import { getBalances } from './balances'
@@ -125,7 +125,7 @@ export const waitForPositions = getWaitFunction(
 export const waitForLiquidations = getWaitFunction(
   (state: RootState) => state.liquidations,
   getLiquidationsInfo,
-  ['contracts', 'trustlessMulticall'],
+  liquidationsDeps
 )
 
 export const waitForRewards = getWaitFunction(


### PR DESCRIPTION
Move liquidationInfo `Dependencies[]` within waitForLiquidations to liquidations slice.
This has the following 2 benefits:
1. it co-locates the dependencies to each slice;
2. it ensures the resultant string[] is isomorphic to U(keyof liquidArgs).

Downside: 
1. the boilerplate which discretizes the type into an object.