### PR TITLE
Reimplement utils.addCommas to avoid lookbehind regexes

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -112,7 +112,15 @@ export const roundToXDecimals = (val: number, decimals: number = 0, floor = fals
 
 export const addCommas = (val: number | string): string => {
   if (typeof val === 'number') val = val.toString()
-  return val.replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ",")
+  let parts = val.split(".")
+  let whole = parts[0].split("")
+  const start = whole.length - 3;
+  const end = (whole[0] === '-') ? 2 : 1;
+  for(let i = start; i >= end; i -= 3) {
+    whole.splice(i, 0, ',')
+  }
+  parts[0] = whole.join("")
+  return parts.join(".")
 }
 
 export const zeroIfNaN = (val: number) => isNaN(val) ? 0 : val


### PR DESCRIPTION
It looks like lookbehind regexes have [partial support](https://caniuse.com/js-regexp-lookbehind) in browsers - and any browser that doesn't support this type of regular expression will throw an error when it sees one.  i ended up reimplementing the method avoiding regex altogether for better or for worse.

tested the reimplementation with:

```
for(let i = 1; i <= 10**10; i *= 10){
    console.log(utils.addCommas(`${i}`)
    console.log(utils.addCommas(`-${i}`)
    console.log(utils.addCommas(`${i}.1234`)
    console.log(utils.addCommas(`-${i}.1234`)
}
```

all outputs seemed good!

after the changes, the site loads on mobile - and now says that mobile isn't supported (vs. a blank white screen) - i'm assuming this is intended.